### PR TITLE
python client library concurrency / flow control

### DIFF
--- a/pyworker/tornado.py
+++ b/pyworker/tornado.py
@@ -1,10 +1,10 @@
 """ workflow worker library using the tornado asynchronous library
 """
 import pika
-from pika import adapters
 from pika.adapters.tornado_connection import TornadoConnection
 
 from .dispatcher import BaseQueueDispatcher
+
 
 class MessageQueueDispatcher(BaseQueueDispatcher):
     """ Register with the AMQP server and process incomimg messages from


### PR DESCRIPTION
Run the user specified handler via the executor. Use a blocking connection
to send replies to the workflow-manager to ensure that messages do not
get queued after all the incoming events. The pika connection send processing
is strange and queues events even if the socket is not send blocked.